### PR TITLE
Generate Schema from python

### DIFF
--- a/flaskinventory/flaskdgraph/dgraph_types.py
+++ b/flaskinventory/flaskdgraph/dgraph_types.py
@@ -253,6 +253,7 @@ class _PrimitivePredicate:
     """
 
     dgraph_predicate_type = 'string'
+    dgraph_directives = None
     is_list_predicate = False
     default_operator = "eq"
     default_connector = "OR"
@@ -276,7 +277,8 @@ class _PrimitivePredicate:
                  tom_select=False,
                  render_kw: dict = None,
                  predicate_alias: list = None,
-                 comparison_operators: str = None) -> None:
+                 comparison_operators: str = None,
+                 directives: list = None) -> None:
         """
             Contruct a new Primitive Predicate
         """
@@ -292,6 +294,12 @@ class _PrimitivePredicate:
         self.query_description = query_description
         self.permission = permission
         self.operators = comparison_operators
+
+        if directives:
+            if self.dgraph_directives:
+                self.dgraph_directives += directives
+            else:
+                self.dgraph_directives = directives
 
         # Facets: parameter should accept lists and single Facet objects
         if isinstance(facets, Facet):
@@ -530,7 +538,7 @@ class Predicate(_PrimitivePredicate):
 class Scalar:
 
     """
-        Utility class for 
+        Utility class for Single Values
     """
 
     def __init__(self, value, facets=None):
@@ -814,6 +822,7 @@ class ReverseListRelationship(ReverseRelationship):
 class MutualRelationship(_PrimitivePredicate):
 
     dgraph_predicate_type = 'uid'
+    dgraph_directives = ['@reverse']
     is_list_predicate = False
     default_operator = "uid_in"
 
@@ -956,6 +965,11 @@ class String(Predicate):
 
 class UIDPredicate(Predicate):
 
+    """
+        This class represents the uid value that each node in Dgraph has by default.
+        Not to be confused with relationships!        
+    """
+
     dgraph_predicate_type = 'uid'
     is_list_predicate = False
     default_operator = 'uid_in'
@@ -1022,6 +1036,8 @@ class ListString(String):
 
 class UniqueName(String):
 
+    dgraph_directives = ['@index(hash, trigram)', '@upsert']
+
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(required=True, new=False,
                          permission=USER_ROLES.Reviewer, *args, **kwargs)
@@ -1041,6 +1057,8 @@ class UniqueName(String):
 
 
 class SingleChoice(String):
+
+    dgraph_directives = ['@index(hash)']
 
     def __init__(self, choices: dict = None, default='NA', radio_field=False, *args, **kwargs) -> None:
 
@@ -1301,6 +1319,7 @@ class Geo(Predicate):
 class SingleRelationship(Predicate):
 
     dgraph_predicate_type = 'uid'
+    dgraph_directives = ['@reverse']
     is_list_predicate = False
     default_operator = 'uid_in'
 
@@ -1421,6 +1440,7 @@ class SingleRelationship(Predicate):
 class ListRelationship(SingleRelationship):
 
     dgraph_predicate_type = '[uid]'
+    dgraph_directives = ['@reverse']
     is_list_predicate = True
     default_connector = "AND"
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,22 @@
+# Ugly hack to allow absolute import from the root folder
+# whatever its name is. Please forgive the heresy.
+
+if __name__ == "__main__":
+    from sys import path
+    from os.path import dirname
+    from flask import request, url_for
+    import unittest
+
+    path.append(dirname(path[0]))
+    from test_setup import BasicTestSetup
+    from flaskinventory import dgraph
+    from flaskinventory.main.model import Schema
+
+
+class TestSchema(BasicTestSetup):
+
+    def test_schema_generation(self):
+        Schema.generate_dgraph_schema()
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)

--- a/tools/setschema.py
+++ b/tools/setschema.py
@@ -1,9 +1,14 @@
 import sys
+from os.path import dirname
+sys.path.append(dirname(sys.path[0]))
+
 import pydgraph
-from colorama import init, deinit, Fore, Style
+import colorama
+from colorama import Fore, Style
+from flaskinventory.main.model import Schema
 
 def main():
-    init()
+    colorama.init()
     print(Fore.RED + 'WARNING!' + Style.RESET_ALL + " You are about to delete all data in DGraph.")
     user_warning = input('Are you sure you want to proceed? (y/n): ')
     
@@ -12,8 +17,9 @@ def main():
         sys.exit()
     
     # load schema
-    with open('./data/schema.dgraph', 'r') as f:
-        schema = f.read()
+    # with open('./data/schema.dgraph', 'r') as f:
+    #     schema = f.read()
+    schema = Schema.generate_dgraph_schema()
     
     client_stub = pydgraph.DgraphClientStub('localhost:9080')
     client = pydgraph.DgraphClient(client_stub)
@@ -24,7 +30,7 @@ def main():
     client.alter(pydgraph.Operation(schema=schema))
     client_stub.close()
     print(Fore.GREEN + 'DONE!' + Style.RESET_ALL)
-    deinit()
+    colorama.deinit()
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This update makes the database model more maintainable. The schema for DGraph is now generated with Python. Note that the current tests fail, because the User class is not part of the schema yet